### PR TITLE
Do not expose control sizes and positions on Transifex

### DIFF
--- a/.tx/strip_resx.xsl
+++ b/.tx/strip_resx.xsl
@@ -7,7 +7,7 @@
 			<xsl:copy-of select="/root/resheader"/>
 			<xsl:for-each select="/root/data">
 				<xsl:sort select="@name" />
-				<xsl:if test="(@name and ((substring(@name, string-length(@name) - 4) = '.Text') or (substring(@name, string-length(@name) - 11) = '.ToolTipText') or (substring(@name, string-length(@name) - 4) = '.Size') or (substring(@name, string-length(@name) - 8) = '.Location') or (substring(@name, string-length(@name) - 10) = '.ClientSize')))">
+				<xsl:if test="(@name and ((substring(@name, string-length(@name) - 4) = '.Text') or (substring(@name, string-length(@name) - 11) = '.ToolTipText')))">
 					<xsl:copy-of select="."/>
 				</xsl:if>
 			</xsl:for-each>


### PR DESCRIPTION
Maintaining them requires manual intervention anyway, so there is absolutely no reason to expose these strings to the localizers.
Having them in Transifex only makes it more difficult to keep them in order.
